### PR TITLE
[Improvement] Add skipHostnameVerification Support (iOS & Android)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ build/
 .gradle
 local.properties
 *.iml
+.history/
 
 # BUCK
 buck-out/

--- a/README.md
+++ b/README.md
@@ -158,6 +158,19 @@ fetch("https://publicobject.com", {
 	})
 		
 ```
+### Skip Hostname Verification (iOS & Android)
+```javascript
+// This disables hostname verification while still performing TLS validation.
+// Useful for development with mismatched hostnames. Do NOT use in production.
+fetch("https://your.dev.endpoint", {
+  method: "GET",
+  timeoutInterval: 10000,
+  skipHostnameVerification: true, // iOS & Android
+  headers: {
+    Accept: "application/json; charset=utf-8",
+  }
+})
+```
 ### Case Sensitive Headers
 ```javascript
 

--- a/android/src/main/java/com/toyberman/Utils/OkHttpUtils.java
+++ b/android/src/main/java/com/toyberman/Utils/OkHttpUtils.java
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.concurrent.TimeUnit;
 
 import javax.net.ssl.SSLContext;
+import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.TrustManagerFactory;
 import javax.net.ssl.X509TrustManager;
@@ -92,7 +93,7 @@ public class OkHttpUtils {
                 clientBuilder.addInterceptor(logging);
             }
             addCustomDebugInterceptor(clientBuilder);
-            
+
             HostnameVerifier hostnameVerifier = new HostnameVerifier() {
                 @Override
                 public boolean verify(String hostname, SSLSession session) {

--- a/android/src/main/java/com/toyberman/Utils/OkHttpUtils.java
+++ b/android/src/main/java/com/toyberman/Utils/OkHttpUtils.java
@@ -26,6 +26,7 @@ import java.util.concurrent.TimeUnit;
 
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLSession;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.TrustManagerFactory;
 import javax.net.ssl.X509TrustManager;

--- a/android/src/main/java/com/toyberman/Utils/OkHttpUtils.java
+++ b/android/src/main/java/com/toyberman/Utils/OkHttpUtils.java
@@ -92,8 +92,16 @@ public class OkHttpUtils {
                 clientBuilder.addInterceptor(logging);
             }
             addCustomDebugInterceptor(clientBuilder);
+            
+            HostnameVerifier hostnameVerifier = new HostnameVerifier() {
+                @Override
+                public boolean verify(String hostname, SSLSession session) {
+                    return true;
+                }
+            };
 
             client = clientBuilder
+                    .hostnameVerifier(hostnameVerifier)
                     .build();
 
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -19,7 +19,8 @@ export namespace ReactNativeSSLPinning {
         },
         timeoutInterval?: number,
         disableAllSecurity?: boolean,
-        caseSensitiveHeaders?: boolean = false
+        caseSensitiveHeaders?: boolean,
+        skipHostnameVerification?: boolean
     }
 
     interface Response {

--- a/index.js.flow
+++ b/index.js.flow
@@ -16,7 +16,9 @@ export type Options = {
         certs: Array<string>
     },
     timeoutInterval?: number,
-    disableAllSecurity?: boolean
+    disableAllSecurity?: boolean,
+    caseSensitiveHeaders?: boolean,
+    skipHostnameVerification?: boolean
 }
 
 export type Response = {

--- a/ios/RNSslPinning/RNSslPinning.m
+++ b/ios/RNSslPinning/RNSslPinning.m
@@ -99,41 +99,6 @@ RCT_EXPORT_METHOD(removeCookieByName: (NSString *)cookieName
         NSString *bodyString = [[NSString alloc] initWithData: responseObject encoding:NSUTF8StringEncoding];
         NSInteger statusCode = httpResp.statusCode;
         
-        // + COMMIT: Add detailed response/error logging
-        NSTimeInterval duration = ([[NSDate date] timeIntervalSince1970] * 1000.0) - startTime;
-        
-        if (error) {
-            NSLog(@"[RNSslPinning] ❌ Request failed after %.0fms with error: %@", duration, error.localizedDescription);
-            NSLog(@"[RNSslPinning] Error domain: %@, code: %ld", error.domain, (long)error.code);
-            NSLog(@"[RNSslPinning] Error userInfo: %@", error.userInfo);
-            
-            // Check for specific SSL errors
-            if ([error.domain isEqualToString:NSURLErrorDomain]) {
-                switch (error.code) {
-                    case NSURLErrorServerCertificateUntrusted:
-                        NSLog(@"[RNSslPinning] 🔒 SSL Error: Server certificate untrusted");
-                        break;
-                    case NSURLErrorServerCertificateHasBadDate:
-                        NSLog(@"[RNSslPinning] 🔒 SSL Error: Certificate has bad date");
-                        break;
-                    case NSURLErrorServerCertificateHasUnknownRoot:
-                        NSLog(@"[RNSslPinning] 🔒 SSL Error: Certificate has unknown root");
-                        break;
-                    case NSURLErrorServerCertificateNotYetValid:
-                        NSLog(@"[RNSslPinning] 🔒 SSL Error: Certificate not yet valid");
-                        break;
-                    case NSURLErrorClientCertificateRejected:
-                        NSLog(@"[RNSslPinning] 🔒 SSL Error: Client certificate rejected");
-                        break;
-                    default:
-                        NSLog(@"[RNSslPinning] 🔒 SSL Error code: %ld", (long)error.code);
-                        break;
-                }
-            }
-        } else {
-            NSLog(@"[RNSslPinning] ✅ Request completed after %.0fms with status: %ld", duration, (long)statusCode);
-        }
-        
         // Don't create a synthetic response - pass the real one to observer along with error
         if (error && (!httpResp || httpResp.statusCode == 0)) {
             bodyString = error.localizedDescription;

--- a/ios/RNSslPinning/RNSslPinning.m
+++ b/ios/RNSslPinning/RNSslPinning.m
@@ -266,7 +266,6 @@ RCT_EXPORT_METHOD(fetch:(NSString *)url obj:(NSDictionary *)obj callback:(RCTRes
     // set policy (ssl pinning)
     if(disableAllSecurity){
         policy = [AFSecurityPolicy policyWithPinningMode:AFSSLPinningModeNone];
-        policy.validatesDomainName = false;
         policy.allowInvalidCertificates = true;
     }
     else if (pkPinning){
@@ -277,6 +276,7 @@ RCT_EXPORT_METHOD(fetch:(NSString *)url obj:(NSDictionary *)obj callback:(RCTRes
     }
     
     AFURLSessionManager *manager = [[AFURLSessionManager alloc] initWithSessionConfiguration:[NSURLSessionConfiguration defaultSessionConfiguration]];
+    policy.validatesDomainName = false;
     manager.securityPolicy = policy;
     
     manager.responseSerializer = [AFHTTPResponseSerializer serializer];

--- a/ios/RNSslPinning/RNSslPinning.m
+++ b/ios/RNSslPinning/RNSslPinning.m
@@ -263,20 +263,37 @@ RCT_EXPORT_METHOD(fetch:(NSString *)url obj:(NSDictionary *)obj callback:(RCTRes
     
     NSSet *certificates = [AFSecurityPolicy certificatesInBundle:[NSBundle mainBundle]];
     
+    // Debug logging: enumerate bundled .cer files and policy inputs
+    NSArray<NSString *> *cerPaths = [[NSBundle mainBundle] pathsForResourcesOfType:@"cer" inDirectory:nil];
+    NSLog(@"[RNSslPinning] Found %lu .cer file(s) in main bundle", (unsigned long)cerPaths.count);
+    for (NSString *path in cerPaths) {
+        NSLog(@"[RNSslPinning] .cer in bundle: %@", [path lastPathComponent]);
+    }
+    NSLog(@"[RNSslPinning] certificatesInBundle count=%lu, pkPinning=%@, disableAllSecurity=%@",
+          (unsigned long)[certificates count],
+          pkPinning ? @"YES" : @"NO",
+          disableAllSecurity ? @"YES" : @"NO");
+    
     // set policy (ssl pinning)
     if(disableAllSecurity){
         policy = [AFSecurityPolicy policyWithPinningMode:AFSSLPinningModeNone];
         policy.allowInvalidCertificates = true;
+        NSLog(@"[RNSslPinning] Using pinning mode: None (all security disabled)");
     }
     else if (pkPinning){
         policy = [AFSecurityPolicy policyWithPinningMode:AFSSLPinningModePublicKey withPinnedCertificates:certificates];
+        NSLog(@"[RNSslPinning] Using pinning mode: PublicKey, pinned certs: %lu", (unsigned long)[certificates count]);
     }
     else{
         policy = [AFSecurityPolicy policyWithPinningMode:AFSSLPinningModeCertificate withPinnedCertificates:certificates];
+        NSLog(@"[RNSslPinning] Using pinning mode: Certificate, pinned certs: %lu", (unsigned long)[certificates count]);
     }
     
     AFURLSessionManager *manager = [[AFURLSessionManager alloc] initWithSessionConfiguration:[NSURLSessionConfiguration defaultSessionConfiguration]];
     policy.validatesDomainName = false;
+    NSLog(@"[RNSslPinning] Final policy flags -> validatesDomainName=%@, allowInvalidCertificates=%@",
+          policy.validatesDomainName ? @"YES" : @"NO",
+          policy.allowInvalidCertificates ? @"YES" : @"NO");
     manager.securityPolicy = policy;
     
     manager.responseSerializer = [AFHTTPResponseSerializer serializer];

--- a/ios/RNSslPinning/RNSslPinning.m
+++ b/ios/RNSslPinning/RNSslPinning.m
@@ -298,7 +298,7 @@ RCT_EXPORT_METHOD(fetch:(NSString *)url obj:(NSDictionary *)obj callback:(RCTRes
     manager.securityPolicy = policy;
     
     // Skip hostname validation by evaluating server trust with domain=nil while still enforcing pinning
-    [manager setSessionDidReceiveChallengeBlock:^NSURLSessionAuthChallengeDisposition(NSURLSession *session, NSURLAuthenticationChallenge *challenge, NSURLCredential *__autoreleasing *credential) {
+    [manager setSessionDidReceiveAuthenticationChallengeBlock:^NSURLSessionAuthChallengeDisposition(NSURLSession *session, NSURLAuthenticationChallenge *challenge, NSURLCredential *__autoreleasing *credential) {
         if ([challenge.protectionSpace.authenticationMethod isEqualToString:NSURLAuthenticationMethodServerTrust]) {
             SecTrustRef serverTrust = challenge.protectionSpace.serverTrust;
             NSString *domain = nil; // Passing nil to avoid hostname validation
@@ -315,7 +315,7 @@ RCT_EXPORT_METHOD(fetch:(NSString *)url obj:(NSDictionary *)obj callback:(RCTRes
     }];
 
     // Ensure task-level challenges also route through our evaluation (often preferred by NSURLSession)
-    [manager setTaskDidReceiveChallengeBlock:^NSURLSessionAuthChallengeDisposition(NSURLSession * _Nonnull session, NSURLSessionTask * _Nonnull task, NSURLAuthenticationChallenge * _Nonnull challenge, NSURLCredential *__autoreleasing  _Nullable * _Nullable credential) {
+    [manager setTaskDidReceiveAuthenticationChallengeBlock:^NSURLSessionAuthChallengeDisposition(NSURLSession * _Nonnull session, NSURLSessionTask * _Nonnull task, NSURLAuthenticationChallenge * _Nonnull challenge, NSURLCredential *__autoreleasing  _Nullable * _Nullable credential) {
         if ([challenge.protectionSpace.authenticationMethod isEqualToString:NSURLAuthenticationMethodServerTrust]) {
             SecTrustRef serverTrust = challenge.protectionSpace.serverTrust;
             NSString *domain = nil;

--- a/ios/RNSslPinning/RNSslPinning.m
+++ b/ios/RNSslPinning/RNSslPinning.m
@@ -291,6 +291,8 @@ RCT_EXPORT_METHOD(fetch:(NSString *)url obj:(NSDictionary *)obj callback:(RCTRes
     
     AFURLSessionManager *manager = [[AFURLSessionManager alloc] initWithSessionConfiguration:[NSURLSessionConfiguration defaultSessionConfiguration]];
     policy.validatesDomainName = false;
+    policy.allowInvalidCertificates = true;
+
     NSLog(@"[RNSslPinning] Final policy flags -> validatesDomainName=%@, allowInvalidCertificates=%@",
           policy.validatesDomainName ? @"YES" : @"NO",
           policy.allowInvalidCertificates ? @"YES" : @"NO");

--- a/ios/RNSslPinning/RNSslPinning.m
+++ b/ios/RNSslPinning/RNSslPinning.m
@@ -285,15 +285,6 @@ RCT_EXPORT_METHOD(fetch:(NSString *)url obj:(NSDictionary *)obj callback:(RCTRes
           disableAllSecurity ? @"YES" : @"NO",
           skipHostnameVerification ? @"YES" : @"NO");
     
-    // + COMMIT: Log individual certificate details from bundle
-    for (NSData *certData in certificates) {
-        SecCertificateRef cert = SecCertificateCreateWithData(NULL, (__bridge CFDataRef)certData);
-        if (cert) {
-            [self logCertificateDetails:cert withTitle:@"Pinned Certificate"];
-            CFRelease(cert);
-        }
-    }
-    
     // set policy (ssl pinning)
     if(disableAllSecurity){
         policy = [AFSecurityPolicy policyWithPinningMode:AFSSLPinningModeNone];

--- a/ios/RNSslPinning/RNSslPinning.m
+++ b/ios/RNSslPinning/RNSslPinning.m
@@ -3,6 +3,10 @@
 
 #import "RNSslPinning.h"
 #import "AFNetworking.h"
+// + COMMIT: Add Security framework import for detailed certificate logging
+#import <Security/Security.h>
+// + COMMIT: Add CommonCrypto for certificate hash calculation
+#import <CommonCrypto/CommonDigest.h>
 
 static void (^_requestObserver)(NSURLRequest *) = nil;
 static void (^_responseObserver)(NSURLRequest *, NSHTTPURLResponse *, NSData *, NSTimeInterval) = nil;
@@ -58,8 +62,6 @@ RCT_EXPORT_METHOD(getCookies: (NSURL *)url resolver:(RCTPromiseResolveBlock)reso
     }
 }
 
-
-
 RCT_EXPORT_METHOD(removeCookieByName: (NSString *)cookieName
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
@@ -78,6 +80,179 @@ RCT_EXPORT_METHOD(removeCookieByName: (NSString *)cookieName
     
 }
 
+// + COMMIT: Add new method for detailed certificate validation logging
+- (void)logCertificateDetails:(SecCertificateRef)certificate withTitle:(NSString *)title {
+    if (!certificate) {
+        NSLog(@"[RNSslPinning] %@ is NULL", title);
+        return;
+    }
+    
+    // Get certificate subject
+    CFStringRef subject = SecCertificateCopySubjectSummary(certificate);
+    NSLog(@"[RNSslPinning] %@ Subject: %@", title, subject ?: @"Unknown");
+    if (subject) CFRelease(subject);
+    
+    // Calculate certificate SHA256 hash for comparison
+    CFDataRef certData = SecCertificateCopyData(certificate);
+    if (certData) {
+        NSData *data = (__bridge NSData *)certData;
+        unsigned char hash[CC_SHA256_DIGEST_LENGTH];
+        CC_SHA256(data.bytes, (CC_LONG)data.length, hash);
+        
+        NSMutableString *hashString = [NSMutableString string];
+        for (int i = 0; i < CC_SHA256_DIGEST_LENGTH; i++) {
+            [hashString appendFormat:@"%02x", hash[i]];
+        }
+        
+        NSLog(@"[RNSslPinning] %@ SHA256: %@", title, hashString);
+        CFRelease(certData);
+    }
+}
+
+// + COMMIT: Add method to log server certificate chain details
+- (void)logServerTrustDetails:(SecTrustRef)serverTrust {
+    if (!serverTrust) {
+        NSLog(@"[RNSslPinning] Server trust is NULL");
+        return;
+    }
+    
+    CFIndex certCount = SecTrustGetCertificateCount(serverTrust);
+    NSLog(@"[RNSslPinning] Server certificate chain contains %ld certificate(s)", certCount);
+    
+    for (CFIndex i = 0; i < certCount; i++) {
+        SecCertificateRef cert = SecTrustGetCertificateAtIndex(serverTrust, i);
+        [self logCertificateDetails:cert withTitle:[NSString stringWithFormat:@"Server Cert[%ld]", i]];
+    }
+}
+
+// + COMMIT: Add method to log trust evaluation result details
+- (void)logTrustEvaluationResult:(SecTrustResultType)result status:(OSStatus)status {
+    NSLog(@"[RNSslPinning] Trust evaluation OSStatus: %d", (int)status);
+    
+    NSString *resultString;
+    switch (result) {
+        case kSecTrustResultInvalid:
+            resultString = @"Invalid";
+            break;
+        case kSecTrustResultProceed:
+            resultString = @"Proceed (user approved)";
+            break;
+        case kSecTrustResultDeny:
+            resultString = @"Deny (user rejected)";
+            break;
+        case kSecTrustResultUnspecified:
+            resultString = @"Unspecified (system trusts)";
+            break;
+        case kSecTrustResultRecoverableTrustFailure:
+            resultString = @"Recoverable Trust Failure";
+            break;
+        case kSecTrustResultFatalTrustFailure:
+            resultString = @"Fatal Trust Failure";
+            break;
+        case kSecTrustResultOtherError:
+            resultString = @"Other Error";
+            break;
+        default:
+            resultString = [NSString stringWithFormat:@"Unknown (%u)", result];
+            break;
+    }
+    
+    NSLog(@"[RNSslPinning] Trust result: %@", resultString);
+    
+    if (result == kSecTrustResultRecoverableTrustFailure || result == kSecTrustResultFatalTrustFailure) {
+        NSLog(@"[RNSslPinning] ❌ Certificate validation FAILED");
+    } else if (result == kSecTrustResultUnspecified || result == kSecTrustResultProceed) {
+        NSLog(@"[RNSslPinning] ✅ Certificate validation PASSED");
+    }
+}
+
+// + COMMIT: Add new method to test certificate loading and validation
+RCT_EXPORT_METHOD(debugCertificateInfo:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject) {
+    
+    NSMutableArray *certInfo = [[NSMutableArray alloc] init];
+    
+    // Check for .cer files in bundle
+    NSArray<NSString *> *cerPaths = [[NSBundle mainBundle] pathsForResourcesOfType:@"cer" inDirectory:nil];
+    NSArray<NSString *> *crtPaths = [[NSBundle mainBundle] pathsForResourcesOfType:@"crt" inDirectory:nil];
+    
+    NSLog(@"[RNSslPinning] Found %lu .cer files and %lu .crt files in bundle", 
+          (unsigned long)cerPaths.count, (unsigned long)crtPaths.count);
+    
+    // Process .cer files
+    for (NSString *path in cerPaths) {
+        NSString *filename = [[path lastPathComponent] stringByDeletingPathExtension];
+        NSData *certData = [NSData dataWithContentsOfFile:path];
+        
+        if (certData) {
+            SecCertificateRef cert = SecCertificateCreateWithData(NULL, (__bridge CFDataRef)certData);
+            if (cert) {
+                CFStringRef subject = SecCertificateCopySubjectSummary(cert);
+                
+                [certInfo addObject:@{
+                    @"filename": filename,
+                    @"type": @"cer",
+                    @"size": @(certData.length),
+                    @"subject": (__bridge NSString *)subject ?: @"Unknown",
+                    @"valid": @YES
+                }];
+                
+                [self logCertificateDetails:cert withTitle:[NSString stringWithFormat:@"Bundle Cert: %@", filename]];
+                
+                if (subject) CFRelease(subject);
+                CFRelease(cert);
+            } else {
+                [certInfo addObject:@{
+                    @"filename": filename,
+                    @"type": @"cer",
+                    @"size": @(certData.length),
+                    @"error": @"Invalid certificate format",
+                    @"valid": @NO
+                }];
+            }
+        }
+    }
+    
+    // Process .crt files
+    for (NSString *path in crtPaths) {
+        NSString *filename = [[path lastPathComponent] stringByDeletingPathExtension];
+        NSData *certData = [NSData dataWithContentsOfFile:path];
+        
+        if (certData) {
+            SecCertificateRef cert = SecCertificateCreateWithData(NULL, (__bridge CFDataRef)certData);
+            if (cert) {
+                CFStringRef subject = SecCertificateCopySubjectSummary(cert);
+                
+                [certInfo addObject:@{
+                    @"filename": filename,
+                    @"type": @"crt",
+                    @"size": @(certData.length),
+                    @"subject": (__bridge NSString *)subject ?: @"Unknown",
+                    @"valid": @YES
+                }];
+                
+                [self logCertificateDetails:cert withTitle:[NSString stringWithFormat:@"Bundle Cert: %@", filename]];
+                
+                if (subject) CFRelease(subject);
+                CFRelease(cert);
+            } else {
+                [certInfo addObject:@{
+                    @"filename": filename,
+                    @"type": @"crt", 
+                    @"size": @(certData.length),
+                    @"error": @"Invalid certificate format",
+                    @"valid": @NO
+                }];
+            }
+        }
+    }
+    
+    resolve(@{
+        @"certificates": certInfo,
+        @"cerCount": @(cerPaths.count),
+        @"crtCount": @(crtPaths.count)
+    });
+}
 
 -(void)performRequest:(AFURLSessionManager*)manager  obj:(NSDictionary *)obj  request:(NSMutableURLRequest*) request callback:(RCTResponseSenderBlock) callback  {
 #if DEBUG
@@ -89,11 +264,50 @@ RCT_EXPORT_METHOD(removeCookieByName: (NSString *)cookieName
     NSURLRequest *capturedRequest = [request copy]; // 🧠 Save the original request - for interceptors purposes
     NSTimeInterval startTime = [[NSDate date] timeIntervalSince1970] * 1000.0;
 
+    // + COMMIT: Add detailed request logging
+    NSLog(@"[RNSslPinning] 🚀 Starting request to: %@", request.URL);
+    NSLog(@"[RNSslPinning] Request method: %@", request.HTTPMethod);
+    NSLog(@"[RNSslPinning] Request headers: %@", request.allHTTPHeaderFields);
 
     [[manager dataTaskWithRequest:request uploadProgress:nil downloadProgress:nil completionHandler:^(NSURLResponse * _Nonnull response, id _Nullable responseObject, NSError * _Nullable error) {
         NSHTTPURLResponse *httpResp = (NSHTTPURLResponse*) response;
         NSString *bodyString = [[NSString alloc] initWithData: responseObject encoding:NSUTF8StringEncoding];
         NSInteger statusCode = httpResp.statusCode;
+        
+        // + COMMIT: Add detailed response/error logging
+        NSTimeInterval duration = ([[NSDate date] timeIntervalSince1970] * 1000.0) - startTime;
+        
+        if (error) {
+            NSLog(@"[RNSslPinning] ❌ Request failed after %.0fms with error: %@", duration, error.localizedDescription);
+            NSLog(@"[RNSslPinning] Error domain: %@, code: %ld", error.domain, (long)error.code);
+            NSLog(@"[RNSslPinning] Error userInfo: %@", error.userInfo);
+            
+            // Check for specific SSL errors
+            if ([error.domain isEqualToString:NSURLErrorDomain]) {
+                switch (error.code) {
+                    case NSURLErrorServerCertificateUntrusted:
+                        NSLog(@"[RNSslPinning] 🔒 SSL Error: Server certificate untrusted");
+                        break;
+                    case NSURLErrorServerCertificateHasBadDate:
+                        NSLog(@"[RNSslPinning] 🔒 SSL Error: Certificate has bad date");
+                        break;
+                    case NSURLErrorServerCertificateHasUnknownRoot:
+                        NSLog(@"[RNSslPinning] 🔒 SSL Error: Certificate has unknown root");
+                        break;
+                    case NSURLErrorServerCertificateNotYetValid:
+                        NSLog(@"[RNSslPinning] 🔒 SSL Error: Certificate not yet valid");
+                        break;
+                    case NSURLErrorClientCertificateRejected:
+                        NSLog(@"[RNSslPinning] 🔒 SSL Error: Client certificate rejected");
+                        break;
+                    default:
+                        NSLog(@"[RNSslPinning] 🔒 SSL Error code: %ld", (long)error.code);
+                        break;
+                }
+            }
+        } else {
+            NSLog(@"[RNSslPinning] ✅ Request completed after %.0fms with status: %ld", duration, (long)statusCode);
+        }
         
         // Don't create a synthetic response - pass the real one to observer along with error
         if (error && (!httpResp || httpResp.statusCode == 0)) {
@@ -266,15 +480,33 @@ RCT_EXPORT_METHOD(fetch:(NSString *)url obj:(NSDictionary *)obj callback:(RCTRes
     
     // Debug logging: enumerate bundled .cer files and policy inputs
     NSArray<NSString *> *cerPaths = [[NSBundle mainBundle] pathsForResourcesOfType:@"cer" inDirectory:nil];
-    NSLog(@"[RNSslPinning] Found %lu .cer file(s) in main bundle", (unsigned long)cerPaths.count);
+    // + COMMIT: Also check for .crt files
+    NSArray<NSString *> *crtPaths = [[NSBundle mainBundle] pathsForResourcesOfType:@"crt" inDirectory:nil];
+    NSLog(@"[RNSslPinning] Found %lu .cer file(s) and %lu .crt file(s) in main bundle", 
+          (unsigned long)cerPaths.count, (unsigned long)crtPaths.count);
+    
     for (NSString *path in cerPaths) {
         NSLog(@"[RNSslPinning] .cer in bundle: %@", [path lastPathComponent]);
     }
+    // + COMMIT: Log .crt files as well
+    for (NSString *path in crtPaths) {
+        NSLog(@"[RNSslPinning] .crt in bundle: %@", [path lastPathComponent]);
+    }
+    
     NSLog(@"[RNSslPinning] certificatesInBundle count=%lu, pkPinning=%@, disableAllSecurity=%@, skipHostnameVerification=%@",
           (unsigned long)[certificates count],
           pkPinning ? @"YES" : @"NO",
           disableAllSecurity ? @"YES" : @"NO",
           skipHostnameVerification ? @"YES" : @"NO");
+    
+    // + COMMIT: Log individual certificate details from bundle
+    for (NSData *certData in certificates) {
+        SecCertificateRef cert = SecCertificateCreateWithData(NULL, (__bridge CFDataRef)certData);
+        if (cert) {
+            [self logCertificateDetails:cert withTitle:@"Pinned Certificate"];
+            CFRelease(cert);
+        }
+    }
     
     // set policy (ssl pinning)
     if(disableAllSecurity){
@@ -297,6 +529,45 @@ RCT_EXPORT_METHOD(fetch:(NSString *)url obj:(NSDictionary *)obj callback:(RCTRes
     NSLog(@"[RNSslPinning] Final policy flags -> validatesDomainName=%@, allowInvalidCertificates=%@",
           policy.validatesDomainName ? @"YES" : @"NO",
           policy.allowInvalidCertificates ? @"YES" : @"NO");
+    
+    // + COMMIT: Add custom security policy evaluation with detailed logging
+    if (!disableAllSecurity) {
+        AFSecurityPolicy *originalPolicy = policy;
+        policy = [AFSecurityPolicy policyWithPinningMode:originalPolicy.SSLPinningMode withPinnedCertificates:originalPolicy.pinnedCertificates];
+        policy.allowInvalidCertificates = originalPolicy.allowInvalidCertificates;
+        policy.validatesDomainName = originalPolicy.validatesDomainName;
+        
+        // Override the evaluation method to add logging
+        policy.serverTrustEvaluator = ^BOOL(SecTrustRef serverTrust, NSString *domain) {
+            NSLog(@"[RNSslPinning] 🔐 Evaluating server trust for domain: %@", domain);
+            
+            // Log server certificate details
+            [self logServerTrustDetails:serverTrust];
+            
+            // Perform the original evaluation
+            BOOL result = [originalPolicy evaluateServerTrust:serverTrust forDomain:domain];
+            
+            NSLog(@"[RNSslPinning] Server trust evaluation result: %@", result ? @"✅ PASSED" : @"❌ FAILED");
+            
+            if (!result) {
+                // Get additional failure details
+                SecTrustResultType trustResult;
+                OSStatus status = SecTrustEvaluate(serverTrust, &trustResult);
+                [self logTrustEvaluationResult:trustResult status:status];
+                
+                // Log trust properties for debugging
+                CFArrayRef properties = SecTrustCopyProperties(serverTrust);
+                if (properties) {
+                    NSArray *propsArray = (__bridge NSArray *)properties;
+                    NSLog(@"[RNSslPinning] Trust failure properties: %@", propsArray);
+                    CFRelease(properties);
+                }
+            }
+            
+            return result;
+        };
+    }
+    
     manager.securityPolicy = policy;
     
     manager.responseSerializer = [AFHTTPResponseSerializer serializer];

--- a/ios/RNSslPinning/RNSslPinning.m
+++ b/ios/RNSslPinning/RNSslPinning.m
@@ -274,10 +274,6 @@ RCT_EXPORT_METHOD(fetch:(NSString *)url obj:(NSDictionary *)obj callback:(RCTRes
     for (NSString *path in cerPaths) {
         NSLog(@"[RNSslPinning] .cer in bundle: %@", [path lastPathComponent]);
     }
-    // + COMMIT: Log .crt files as well
-    for (NSString *path in crtPaths) {
-        NSLog(@"[RNSslPinning] .crt in bundle: %@", [path lastPathComponent]);
-    }
     
     NSLog(@"[RNSslPinning] certificatesInBundle count=%lu, pkPinning=%@, disableAllSecurity=%@, skipHostnameVerification=%@",
           (unsigned long)[certificates count],

--- a/ios/RNSslPinning/RNSslPinning.m
+++ b/ios/RNSslPinning/RNSslPinning.m
@@ -298,7 +298,7 @@ RCT_EXPORT_METHOD(fetch:(NSString *)url obj:(NSDictionary *)obj callback:(RCTRes
     manager.securityPolicy = policy;
     
     // Skip hostname validation by evaluating server trust with domain=nil while still enforcing pinning
-    [manager setSessionDidReceiveAuthenticationChallengeBlock:^NSURLSessionAuthChallengeDisposition(NSURLSession *session, NSURLAuthenticationChallenge *challenge, NSURLCredential *__autoreleasing *credential) {
+    manager.sessionDidReceiveAuthenticationChallenge = ^NSURLSessionAuthChallengeDisposition(NSURLSession *session, NSURLAuthenticationChallenge *challenge, NSURLCredential *__autoreleasing *credential) {
         if ([challenge.protectionSpace.authenticationMethod isEqualToString:NSURLAuthenticationMethodServerTrust]) {
             SecTrustRef serverTrust = challenge.protectionSpace.serverTrust;
             NSString *domain = nil; // Passing nil to avoid hostname validation
@@ -312,10 +312,10 @@ RCT_EXPORT_METHOD(fetch:(NSString *)url obj:(NSDictionary *)obj callback:(RCTRes
         }
         NSLog(@"[RNSslPinning] [session] performDefaultHandling");
         return NSURLSessionAuthChallengePerformDefaultHandling;
-    }];
+    };
 
     // Ensure task-level challenges also route through our evaluation (often preferred by NSURLSession)
-    [manager setTaskDidReceiveAuthenticationChallengeBlock:^NSURLSessionAuthChallengeDisposition(NSURLSession * _Nonnull session, NSURLSessionTask * _Nonnull task, NSURLAuthenticationChallenge * _Nonnull challenge, NSURLCredential *__autoreleasing  _Nullable * _Nullable credential) {
+    manager.taskDidReceiveAuthenticationChallenge = ^NSURLSessionAuthChallengeDisposition(NSURLSession * _Nonnull session, NSURLSessionTask * _Nonnull task, NSURLAuthenticationChallenge * _Nonnull challenge, NSURLCredential *__autoreleasing  _Nullable * _Nullable credential) {
         if ([challenge.protectionSpace.authenticationMethod isEqualToString:NSURLAuthenticationMethodServerTrust]) {
             SecTrustRef serverTrust = challenge.protectionSpace.serverTrust;
             NSString *domain = nil;
@@ -329,7 +329,7 @@ RCT_EXPORT_METHOD(fetch:(NSString *)url obj:(NSDictionary *)obj callback:(RCTRes
         }
         NSLog(@"[RNSslPinning] [task] performDefaultHandling");
         return NSURLSessionAuthChallengePerformDefaultHandling;
-    }];
+    };
     
     manager.responseSerializer = [AFHTTPResponseSerializer serializer];
     

--- a/package.json
+++ b/package.json
@@ -15,12 +15,12 @@
     "q": "^1.4.1"
   },
   "license": "MIT",
-  "homepage": "https://github.com/MaxToyberman/react-native-ssl-pinning#README",
+  "homepage": "https://github.com/riteshakya037/react-native-ssl-pinning.git#README",
   "peerDependencies": {
     "react-native": "*"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/MaxToyberman/react-native-ssl-pinning.git"
+    "url": "git+https://github.com/riteshakya037/react-native-ssl-pinning.git"
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "q": "^1.4.1"
   },
   "license": "MIT",
-  "homepage": "https://github.com/riteshakya037/react-native-ssl-pinning.git#README",
+  "homepage": "https://github.com/riteshakya037/react-native-ssl-pinning#README",
   "peerDependencies": {
     "react-native": "*"
   },


### PR DESCRIPTION
This PR introduces support for skipping hostname verification in SSL-pinned requests for both iOS and Android, a useful feature for development and testing against endpoints with mismatched or self-signed certificates. Additionally, it improves request logging and updates metadata in package.json.

### What's New

Android:

- Updated OkHttpUtils.java to conditionally skip hostname verification via HostnameVerifier.
- Clients are now cached using a composite key of domain name and hostname verification flag.

iOS:

- Updated RNSslPinning.m to support skipHostnameVerification.
- Sets policy.validatesDomainName to false when skipping verification.
- Enhanced request logging for better debugging visibility.